### PR TITLE
added feature: preserve original input order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### v1.1.5-dev; 2025-09-09.1500
+### v1.1.5-dev; 2025-09-09.1600
 ```
+added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
 addressed raw base-16 issue https://github.com/cyclone-github/hashgen/issues/8
 ```
 ### v1.1.4; 2025-08-23


### PR DESCRIPTION
Preserves original input order by default.

Addresses issue: https://github.com/cyclone-github/hashgen/issues/7

Example: https://github.com/cyclone-github/hashgen/issues/7#issuecomment-3272275835