### PR TITLE
11 dynamic linessec stats output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### v1.1.5-dev; 2025-09-09.1600
+### v1.1.5-dev; 2025-09-10.1000
 ```
-added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
 addressed raw base-16 issue https://github.com/cyclone-github/hashgen/issues/8
+added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
+added dynamic lines/sec from https://github.com/cyclone-github/hashgen/issues/9
 ```
 ### v1.1.4; 2025-08-23
 ```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Hashgen is a CLI hash generator written in Go and can be cross compiled for Linu
 To use hashgen, type your mode, wordlist input & hash output files with a simple command line.
 
 ### Features:
+- Maintains original input order [PR 10](https://github.com/cyclone-github/hashgen/pull/10)
 - Supports 38+ modes/functions (see list below)
 - Encode / decode base64 & base58
 - Hex / dehex wordlists
-- Supports ASCII, UTF-8 and $HEX[] wordlist input
+- Supports ASCII, UTF-8 and $HEX[] input
+- Supports UTF-8 (default) or $HEX[] output
 
 | Useage Examples | Command Line |
 |-----------|-----------|

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cyclone-github/base58 v1.0.1
 	github.com/ebfe/keccak v0.0.0-20150115210727-5cc570678d1b
 	github.com/openwall/yescrypt-go v1.0.0
-	golang.org/x/crypto v0.41.0
+	golang.org/x/crypto v0.42.0
 )
 
-require golang.org/x/sys v0.35.0 // indirect
+require golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,7 @@ github.com/ebfe/keccak v0.0.0-20150115210727-5cc570678d1b h1:BMyjwV6Fal/Ffphi4dJ
 github.com/ebfe/keccak v0.0.0-20150115210727-5cc570678d1b/go.mod h1:fnviDXB7GJWiSUI9thIXmk9QKM8Rhj1JV/LcMRzkiVA=
 github.com/openwall/yescrypt-go v1.0.0 h1:jsGk48zkFvtUjGVOhYPGh+CS595JmTRcKnpggK2AON4=
 github.com/openwall/yescrypt-go v1.0.0/go.mod h1:e6CWtFizUEOUttaOjeVMiv1lJaJie3mfOtLJ9CCD6sA=
-golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
-golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
-golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
-golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
+golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hashgen.go
+++ b/hashgen.go
@@ -87,7 +87,7 @@ v1.1.4; 2025-08-23
 v1.1.5-dev; 2025-09-10.1000
 	addressed raw base-16 issue https://github.com/cyclone-github/hashgen/issues/8
 	added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
-	added dynamic lines/sec from https://github.com/cyclone-github/hashgen/issues/9
+	added dynamic lines/sec from https://github.com/cyclone-github/hashgen/issues/11
 */
 
 func versionFunc() {

--- a/hashgen.go
+++ b/hashgen.go
@@ -84,13 +84,14 @@ v1.1.4; 2025-08-23
 	added benchmark flag, -b (to benchmark current mode, disables output)
 	compiled with Go v1.25.0 which gives a small performance boost to multiple algos
 	added notes concerning some NTLM hashes not being crackable with certain hash cracking tools due to encoding gremlins
-v1.1.5-dev; 2025-09-09.1600
-	added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
+v1.1.5-dev; 2025-09-10.1000
 	addressed raw base-16 issue https://github.com/cyclone-github/hashgen/issues/8
+	added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
+	added dynamic lines/sec from https://github.com/cyclone-github/hashgen/issues/9
 */
 
 func versionFunc() {
-	fmt.Fprintln(os.Stderr, "Cyclone hash generator v1.1.5-dev; 2025-09-09.1600\nhttps://github.com/cyclone-github/hashgen")
+	fmt.Fprintln(os.Stderr, "Cyclone hash generator v1.1.5-dev; 2025-09-10.1000\nhttps://github.com/cyclone-github/hashgen")
 }
 
 // help function
@@ -701,12 +702,36 @@ func startProc(hashFunc string, inputFile string, outputPath string, hashPlainOu
 
 	// print stats
 	elapsedTime := time.Since(startTime)
-	runTime := float64(elapsedTime.Seconds())
-	linesPerSecond := float64(linesHashed) / elapsedTime.Seconds() * 0.000001
+	runTime := elapsedTime.Seconds()
+
+	lps := float64(linesHashed) / runTime // raw lines/sec
+
+	unit := ""    // < 1 K (oh, so slow)
+	scaled := lps // lines per second
+	switch {
+	case lps >= 1e12: // Trillion (not likely!)
+		unit = "T"
+		scaled = lps / 1e12
+	case lps >= 1e9: // Billion (what CPU is this?)
+		unit = "B"
+		scaled = lps / 1e9
+	case lps >= 1e6: // Million (yep)
+		unit = "M"
+		scaled = lps / 1e6
+	case lps >= 1e3: // Thousand (still so slow)
+		unit = "K"
+		scaled = lps / 1e3
+	}
+
 	if hexDecodeErrors > 0 {
 		log.Printf("HEX decode errors: %d\n", hexDecodeErrors)
 	}
-	log.Printf("Finished processing %d lines in %.3f sec (%.3f M lines/sec)\n", linesHashed, runTime, linesPerSecond)
+
+	if unit == "" {
+		log.Printf("Finished processing %d lines in %.3f sec (%.3f lines/sec)\n", linesHashed, runTime, scaled) // < 1 K
+	} else {
+		log.Printf("Finished processing %d lines in %.3f sec (%.3f %s lines/sec)\n", linesHashed, runTime, scaled, unit) // K +
+	}
 }
 
 // main func


### PR DESCRIPTION
addressed https://github.com/cyclone-github/hashgen/issues/11

### Example:
Current stats line output:
`Finished processing 3220 lines in 3.224 sec (0.001 M lines/sec)`
With dynamic stats line output:
`Finished processing 3220 lines in 3.224 sec (998.637 lines/sec)`