### PR TITLE
add mode: cmiyc ($cmiyc$2026$)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ add mode: gost-yescrypt
 add mode: SSHA -m 111
 add mode: sha1crypt -m 15100
 add mode: sm3crypt -m 35100
+add mode: cmiyc (KoreLogic CMIYC 2026 contest algo)
 ```
 ### v1.3.1; 2026-04-13
 ```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 | sha256crypt | 7400 (`Linux shadow $5$`) |
 | sha512crypt | 1800 (`Linux shadow $6$`) |
 | sm3crypt | 35100 (`Unix $sm3$`) |
+| cmiyc | (`KoreLogic CMIYC 2026 contest algo`) |
 | phpass | 400 (`PHP/WordPress $P$/phpBB3 $H$`) |
 | gost-yescrypt | (`Linux shadow $gy$`) |
 | yescrypt | (`Linux shadow $y$`) |

--- a/hashgen.go
+++ b/hashgen.go
@@ -73,6 +73,7 @@ v1.3.2; 2026-08-18
 	add mode: SSHA -m 111
 	add mode: sha1crypt -m 15100
 	add mode: sm3crypt -m 35100
+	add mode: cmiyc (KoreLogic CMIYC 2026 contest algo)
 */
 
 func versionFunc() {
@@ -168,6 +169,7 @@ func helpFunc() {
 		"1770\t\t(hashcat compatible sha512 utf16le($pass))\n" +
 		"sha512crypt\t1800 (Linux shadow $6$)\n" +
 		"sm3crypt\t35100 (Unix $sm3$)\n" +
+		"cmiyc\t\t(KoreLogic CMIYC 2026 contest algo)\n" +
 		"50\t\t(hashcat compatible HMAC-MD5 key = $pass)\n" +
 		"60\t\t(hashcat compatible HMAC-MD5 key = $salt)\n" +
 		"150\t\t(hashcat compatible HMAC-SHA1 key = $pass)\n" +
@@ -1122,6 +1124,90 @@ func sm3crypt(password []byte, saltRaw []byte) string {
 	return string(out)
 }
 
+const (
+	cmiycRounds  = uint32(4)
+	cmiycMemLog  = uint32(16)
+	cmiycMemSize = 64 << cmiycMemLog
+)
+
+var cmiycMemPool = sync.Pool{New: func() any { return make([]byte, cmiycMemSize) }}
+
+// cmiyc 2026 contest algo - memory-hard SHA-512 KDF
+func cmiyc(password []byte, saltRaw []byte) string {
+	var salt [16]byte
+	if len(saltRaw) >= len(salt) {
+		copy(salt[:], saltRaw[:len(salt)])
+	} else if !readRand(salt[:]) {
+		return ""
+	}
+
+	mem := cmiycMemPool.Get().([]byte)
+	defer cmiycMemPool.Put(mem)
+
+	mac := hmac.New(sha512.New, salt[:])
+	_, _ = mac.Write(password)
+	var params [8]byte
+	binary.LittleEndian.PutUint32(params[:4], cmiycRounds)
+	binary.LittleEndian.PutUint32(params[4:], cmiycMemLog)
+	_, _ = mac.Write(params[:])
+	seed := mac.Sum(nil)
+
+	const n = 1 << cmiycMemLog
+	const mask = n - 1
+
+	var fill [82]byte
+	copy(fill[:64], seed)
+	copy(fill[64:74], "cmiyc-fill")
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			copy(fill[:64], mem[(i-1)*64:i*64])
+		}
+		binary.LittleEndian.PutUint64(fill[74:], uint64(i))
+		sum := sha512.Sum512(fill[:])
+		copy(mem[i*64:(i+1)*64], sum[:])
+	}
+
+	var mix [145]byte
+	for r := uint64(1); r <= uint64(cmiycRounds); r++ {
+		binary.LittleEndian.PutUint64(mix[128:136], r)
+		mix[144] = 'A'
+		for i := 0; i < n; i++ {
+			off := i * 64
+			j := int(binary.LittleEndian.Uint64(mem[off:off+8])&mask) * 64
+			copy(mix[:64], mem[off:off+64])
+			copy(mix[64:128], mem[j:j+64])
+			binary.LittleEndian.PutUint64(mix[136:144], uint64(i))
+			sum := sha512.Sum512(mix[:])
+			copy(mem[off:off+64], sum[:])
+		}
+
+		mix[144] = 'B'
+		for i := n; i > 0; i-- {
+			idx := i - 1
+			off := idx * 64
+			j := int(binary.LittleEndian.Uint64(mem[off+8:off+16])&mask) * 64
+			copy(mix[:64], mem[off:off+64])
+			copy(mix[64:128], mem[j:j+64])
+			binary.LittleEndian.PutUint64(mix[136:144], uint64(idx))
+			sum := sha512.Sum512(mix[:])
+			copy(mem[off:off+64], sum[:])
+		}
+	}
+
+	var x [64]byte
+	for i := 0; i < n; i++ {
+		off := i * 64
+		for j := range x {
+			x[j] ^= mem[off+j]
+		}
+	}
+	final := sha512.Sum512(x[:])
+
+	enc := base64.RawURLEncoding
+	return fmt.Sprintf("$cmiyc$2026$%d$%d$%s$%s",
+		cmiycRounds, cmiycMemLog, enc.EncodeToString(salt[:]), enc.EncodeToString(final[:32]))
+}
+
 // WordPress bcrypt: $wp$2y$10$<22-salt><31-hash>
 // bcrypt(base64(HMAC-SHA384(key="wp-sha384",$password)))
 func wpbcrypt(password []byte, cost int) string {
@@ -1276,7 +1362,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 			"8900", "scrypt",
 			"10900", "pbkdf2-sha256", "11900", "pbkdf2-md5", "12000", "pbkdf2-sha1", "12100", "pbkdf2-sha512",
 			"bcrypt", "3200", "wpbcrypt",
-			"md5crypt", "500", "sha1crypt", "15100", "sha256crypt", "7400", "sha512crypt", "1800", "sm3crypt", "35100",
+			"md5crypt", "500", "sha1crypt", "15100", "sha256crypt", "7400", "sha512crypt", "1800", "sm3crypt", "35100", "cmiyc",
 			"phpass", "phpbb3", "400":
 			return "", true
 		}
@@ -2167,6 +2253,10 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 	case "sm3crypt", "35100":
 		return sm3crypt(data, nil), true
 
+	// CMIYC 2026
+	case "cmiyc":
+		return cmiyc(data, nil), true
+
 	// sha256crypt ($5$) -m 7400
 	case "sha256crypt", "7400":
 		return sha256crypt(data), true
@@ -2259,12 +2349,13 @@ func startProc(hashFunc string, inputFile string, outputPath string, hashPlainOu
 		}
 	}
 
-	// lower read buffer for argon2id, yescrypt, gost-yescrypt, scrypt
+	// lower read buffer for argon2id, yescrypt, gost-yescrypt, scrypt, cmiyc
 	{
 		bufSlow := map[string]bool{
 			"argon2id": true, "34000": true,
 			"yescrypt": true, "gost-yescrypt": true,
-			"8900": true, "scrypt": true,
+			"cmiyc": true,
+			"8900":  true, "scrypt": true,
 		}
 		if bufSlow[hashFunc] {
 			readBufferSize = numGoroutines + 8*2


### PR DESCRIPTION
Adds support for the custom memory-hard KDF hash algo used in CMIYC 2026. This algo was created by KoreLogic for CMIYC 2026 and at this time has no other practical purpose outside of the contest. 

### Parameters

```text
mode:      cmiyc
rounds:    4
memlog:    16
memory:    4 MiB per KDF candidate
salt:      random 16 bytes
format:    $cmiyc$2026$4$16$<salt>$<digest>
```

### Example 

```
$ echo "hashgen" | hashgen -m cmiyc
2026/08/18 10:36:38 Starting...
2026/08/18 10:36:38 Reading from stdin...
2026/08/18 10:36:38 Hash function: cmiyc
2026/08/18 10:36:38 CPU Threads: 16
$cmiyc$2026$4$16$3MUwyBLiyd3IzNKjtbKfCg$ZWfuY36nvFHp3IJ9ohVuipJhjJI_G-PHCaMwnq0ef4E
2026/08/18 10:36:38 Finished processing 1 lines in 0.230 sec (4.353 lines/sec)
```

### Algorithm overview from reverse engineered CMIYC 2026 Challenge 3 binary: `cmiyc_2026_challenge_3`

CMIYC 2026 Memory-Hard SHA-512 KDF

```text
$cmiyc$2026$<rounds>$<memlog>$<salt_b64url>$<digest_b64url>
```

Parameters and encoding:

- `rounds`: decimal integer, valid range 1..32.
- `memlog`: decimal integer, valid range 10..24.
- `salt`: exactly 16 bytes, unpadded RFC 4648 Base64URL.
- `digest`: exactly 32 bytes, unpadded RFC 4648 Base64URL.
- Number of memory blocks: `N = 1 << memlog`.
- Each memory block is 64 bytes, so memory per candidate is `64 * 2^memlog` bytes.
- All integer values injected into the KDF are little-endian.
- The literal `2026` is part of the modular hash format/version check, but it is not hashed by the KDF.

### KDF

```text
N = 1 << memlog

seed = HMAC-SHA512(
    key = salt,
    msg = password || LE32(rounds) || LE32(memlog)
)

M[0] = SHA512(seed || "cmiyc-fill" || LE64(0))

for i = 1 .. N-1:
    M[i] = SHA512(M[i-1] || "cmiyc-fill" || LE64(i))

for r = 1 .. rounds:

    # Forward pass, in place
    for i = 0 .. N-1:
        current = M[i]
        j = LE64(current[0:8]) & (N - 1)
        M[i] = SHA512(
            current || M[j] || LE64(r) || LE64(i) || "A"
        )

    # Reverse pass, in place
    for i = N-1 .. 0:
        current = M[i]
        j = LE64(current[8:16]) & (N - 1)
        M[i] = SHA512(
            current || M[j] || LE64(r) || LE64(i) || "B"
        )

X = 64 zero bytes
for i = 0 .. N-1:
    X = X XOR M[i]

full = SHA512(X)
digest = full[0:32]
```

Important implementation details:

- HMAC key is the 16-byte salt. The password is in the HMAC message.
- The fill tag is exactly the 10 ASCII bytes `cmiyc-fill`, with no NUL terminator.
- Fill begins at index 0.
- Mixing round numbers begin at 1.
- Forward indexing uses bytes 0..7 of the current block.
- Reverse indexing uses bytes 8..15 of the current block.
- Both mixing passes mutate the memory array in place. `M[j]` therefore observes whatever value is currently in that slot at that point in the pass.
- Forward domain separator is one byte `A`; reverse separator is one byte `B`.
- The final reduction XORs every byte of all 64-byte blocks into one 64-byte accumulator.
- The final SHA-512 is truncated to its first 32 bytes.

### Default-cost example

For `rounds=4`, `memlog=16`:

- `N = 65,536` blocks.
- Memory per candidate = 4 MiB.
- Fill performs 65,536 SHA-512 hashes.
- Mixing performs `2 * 4 * 65,536 = 524,288` SHA-512 hashes.
- Each 145-byte mixing message spans two SHA-512 compression blocks.

### Known test vectors

Password `Always`, salt hex `000102030405060708090a0b0c0d0e0f`:

```text
$cmiyc$2026$1$10$AAECAwQFBgcICQoLDA0ODw$PeDdIxtm9EBCX5W2QI9GTX9UVM4Vp-iPT-ntbNzcd_Q
```

Using the same password/salt with `rounds=4`, `memlog=16`:

```text
$cmiyc$2026$4$16$AAECAwQFBgcICQoLDA0ODw$bPFnwgOl8XRYP3vMkEOl9fpebKwF8GFpMAAWCJR4Ptg
```