### PR TITLE
correct formatting / typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ add mode: gost-yescrypt
 add mode: SSHA -m 111
 add mode: sha1crypt -m 15100
 add mode: sm3crypt -m 35100
-add mode: cmiyc (KoreLogic CMIYC 2026 contest algo)
+add mode: cmiyc (KoreLogic CMIYC 2026 contest algorithm)
 add modes: Streebog/GOST 2012 -m 11700, 11750, 11760, 11800, 11850, 11860
 add modes: SHA-384 UTF-16LE -m 10830, 10840, 10870
 add modes: LDAP SHA/SSHA -m 101, 1411, 1711
@@ -26,7 +26,7 @@ added scrypt mode: -m 8900
 added BLAKE2 modes: -m 600, 610, 620, 31000, 34800, 34810, 34820, 33300
 added hashcat UTF-16LE modes: -m 30, 40, 70, 130, 140, 170, 1430, 1440, 1470, 1730, 1740, 1770
 optimized salt RNG for fewer syscalls on salted hash modes
-added sanity check on invalid -m nth before opening stdin/wordlist
+added sanity check on invalid -m mode before opening stdin/wordlist
 compiled with Go v1.26.2
 ```
 ### v1.2.2; 2026-01-23
@@ -43,21 +43,21 @@ added mode: morsedecode (Morse Code decoder)
 addressed raw base-16 issue https://github.com/cyclone-github/hashgen/issues/8
 added feature: "keep-order" from https://github.com/cyclone-github/hashgen/issues/7
 added dynamic lines/sec from https://github.com/cyclone-github/hashgen/issues/11
-added modes: mysql5 (300), phpass (400), md5crypt (500), sha256crypt (7400), sha512crypt (1800), Wordpress bcrypt-HMAC-SHA384 (wpbcrypt)
+added modes: mysql5 (300), phpass (400), md5crypt (500), sha256crypt (7400), sha512crypt (1800), WordPress bcrypt-HMAC-SHA384 (wpbcrypt)
 added hashcat salted modes: -m 10, 20, 110, 120, 1410, 1420, 1310, 1320, 1710, 1720, 10810, 10820
 added hashcat modes: -m 2600, 4500
 added encoding modes: base32encode, base32decode
-cleaned up hashFunc aliases, algo typo, hex mode, hashBytes case switch, base64 and base58 decoders
+cleaned up hashFunc aliases, algorithm typo, hex mode, hashBytes case switch, base64 and base58 decoders
 fixed ntlm encoding issue
 added sanity check to not print blank / invalid hash lines (part of ntlm fix, but applies to all hash modes)
 converted checkForHex from string to byte
-updated yescrypt parameters to match debian 12 (libxcrypt) defaults
+updated yescrypt parameters to match Debian 12 (libxcrypt) defaults
 ```
 ### v1.1.4; 2025-08-23
 ```
 added modes: keccak-224, keccak-384, blake2b-256, blake2b-384, blake2b-512, blake2s-256
 added benchmark flag, -b (to benchmark current mode, disables output)
-compiled with Go v1.25.0 which gives a small performance boost to multiple algos
+compiled with Go v1.25.0 which gives a small performance boost to multiple algorithms
 added notes concerning some NTLM hashes not being crackable with certain hash cracking tools due to encoding gremlins
 ```
 ### v1.1.3; 2025-06-30
@@ -91,7 +91,7 @@ cleaned up code and print functions
 ```
 ### v2024-11-01.1630-threaded
 ```
-added thread flag "-t" to allow user to specity CPU threads, ex: -t 16 // fixed default to use max CPU threads
+added thread flag "-t" to allow user to specify CPU threads, ex: -t 16 // fixed default to use max CPU threads
 added modes: sha2-224, sha2-384, sha2-512-224, sha2-512-256, keccak-256, keccak-512
 ```
 ### v2024-08-24.2000-threaded
@@ -113,5 +113,5 @@ fixed stdin
 ### v2023-10-30.1600-threaded
 ```
 rewrote code base for multi-threading support
-some algos have not been implemented from previous version
+some algorithms have not been implemented from previous version
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Readme Card](https://github-readme-stats-fast.vercel.app/api/pin/?username=cyclone-github&repo=hashgen&theme=gruvbox)](https://github.com/cyclone-github/hashgen/)
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/cyclone-github/hashgen)](https://goreportcard.com/report/github.com/cyclone-github/hashgen)
 [![GitHub issues](https://img.shields.io/github/issues/cyclone-github/hashgen.svg)](https://github.com/cyclone-github/hashgen/issues)
 [![License](https://img.shields.io/github/license/cyclone-github/hashgen.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/release/cyclone-github/hashgen.svg)](https://github.com/cyclone-github/hashgen/releases)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 [![GitHub release](https://img.shields.io/github/release/cyclone-github/hashgen.svg)](https://github.com/cyclone-github/hashgen/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/cyclone-github/hashgen.svg)](https://pkg.go.dev/github.com/cyclone-github/hashgen)
 
-### Install latest published release:
-```
-go install github.com/cyclone-github/hashgen@latest
-```
-### Install latest source code (bleeding edge):
+### Install latest from source code:
 ```
 go install github.com/cyclone-github/hashgen@main
 ```
@@ -18,29 +14,29 @@ go install github.com/cyclone-github/hashgen@main
 # hashgen - Cyclone's hash generator
 ```
 $ hashgen -m md5 -w rockyou.txt -b
-2026/04/11 12:28:58 Starting...
-2026/04/11 12:28:58 Processing file: /media/ramdisk/rockyou.txt
-2026/04/11 12:28:58 Hash function: 0
-2026/04/11 12:28:58 CPU Threads: 16
-2026/04/11 12:28:58 Finished processing 14344391 lines in 0.446 sec (32.127 M lines/sec)
+2026/08/18 18:26:09 Starting...
+2026/08/18 18:26:09 Processing file: /media/ramdisk/rockyou.txt
+2026/08/18 18:26:09 Hash function: 0
+2026/08/18 18:26:09 CPU Threads: 16
+2026/08/18 18:26:10 Finished processing 14344391 lines in 0.443 sec (32.346 M lines/sec)
 ```
-Hashgen has a top recorded hashrate of 32.127 million md5/sec on the test rig's Ryzen 7 3700X CPU. (see benchmarks) Much faster hashrates have been seen on newer / faster CPU's.
+Hashgen has a top recorded hashrate of 32.346 million md5/sec on the test rig's Ryzen 7 3700X CPU. (see benchmarks) Much faster hashrates have been seen on newer / faster CPUs.
 
-Hashgen is a CLI hash generator written in Go and can be cross compiled for Linux, Raspberry Pi, Windows & Mac, although testing and compiling is mainly done on debian 12 linux.
+Hashgen is a CLI hash generator written in Go and can be cross-compiled for Linux, Raspberry Pi, Windows & Mac, although testing and compiling is mainly done on Debian 12 Linux.
 
 To use hashgen, type your mode, wordlist input & hash output files with a simple command line.
 
 ### Features:
 - Maintains original input order [PR 10](https://github.com/cyclone-github/hashgen/pull/10)
-- Supports 100+ modes/functions (see list below)
+- Supports 130+ modes/functions (see list below)
 - Encode / decode base64, base58, base32
 - Hex / dehex wordlists
 - Supports ASCII, UTF-8 and $HEX[] input
 - Supports UTF-8 (default) or $HEX[] output
 - Supports multiple salted modes
-- Supports HMAC, KDF, scrypt, bcrypt, linux shadow modes, checksums, morsecode, etc
+- Also supports HMAC, KDF, scrypt, bcrypt, Linux shadow modes, checksums, morsecode, etc
 
-| Useage Examples | Command Line |
+| Usage Examples | Command Line |
 |-----------|-----------|
 | read wordlist.txt, hash to md5 and write to output.txt | ./hashgen -m md5 -w wordlist.txt -o output.txt |
 | pipe wordlist into hashgen and write to stdout | cat wordlist.txt \| ./hashgen -m md5 |
@@ -52,7 +48,7 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 ### Supported Options:
 | Flag: | Description: |
 |-----------|-----------|
-| -m  | {mode} | 
+| -m  | {mode} |
 | -w  | {wordlist input} |
 | -t  | {cpu threads} |
 | -o  | {wordlist output} |
@@ -67,7 +63,7 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 | Function: | Hashcat Mode: |
 |-----------------|----------------|
 | **`Plaintext & Encoding`** | |
-| plaintext / dehex | 99999 (decode $HEX[]) |
+| plaintext/dehex | 99999 (decode $HEX[]) |
 | hex | (encode to $HEX[]) |
 | base32decode | |
 | base32encode | |
@@ -80,123 +76,124 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 | | |
 | **`Checksums`** | |
 | crc32 | |
-| 11500 | (hashcat compatible CRC32) |
+| 11500 | (CRC32 Hashcat format) |
 | crc64 | |
 | | |
 | **`MDx`** | |
 | md4 | 900 |
 | md5 | 0 |
-| md5md5 | 2600 |
-| 3500 | (hashcat compatible md5(md5(md5($pass)))) |
-| 4300 | (hashcat compatible md5(strtoupper(md5($pass)))) |
-| 4400 | (hashcat compatible md5(sha1($pass))) |
-| 32800 | (hashcat compatible md5(sha1(md5($pass)))) |
 | halfmd5 | 5100 |
 | md5passsalt | 10 |
 | md5saltpass | 20 |
-| 30 | (hashcat compatible md5 utf16le($pass).$salt) |
-| 40 | (hashcat compatible md5 $salt.utf16le($pass)) |
-| 50 | (hashcat compatible HMAC-MD5 key = $pass) |
-| 60 | (hashcat compatible HMAC-MD5 key = $salt) |
-| 70 | (hashcat compatible md5 utf16le($pass)) |
+| md5utf16passsalt | 30 |
+| md5utf16saltpass | 40 |
+| hmacmd5pass | 50 |
+| hmacmd5salt | 60 |
+| md5utf16le | 70 |
+| md5md5 | 2600 |
+| 3500 | (md5(md5(md5($pass)))) |
+| 4300 | (md5(strtoupper(md5($pass)))) |
+| 4400 | (md5(sha1($pass))) |
+| 32800 | (md5(sha1(md5($pass)))) |
 | | |
 | **`MD6`** | |
-| md6-128 | |
-| md6-224 | |
-| md6-256 | 34600 |
-| md6-384 | |
-| md6-512 | |
+| md6128 | |
+| md6224 | |
+| md6256 | 34600 |
+| md6384 | |
+| md6512 | |
+| | |
 | **`SHA1`** | |
 | sha1 | 100 |
-| ldap-sha | 101 (Netscape LDAP {SHA}) |
-| sha1sha1 | 4500 |
-| 4700 | (hashcat compatible sha1(md5($pass))) |
-| 18500 | (hashcat compatible sha1(md5(md5($pass)))) |
-| 18501 | (sha1(md5(sha1($pass)))) |
+| ldapsha | 101 (Netscape LDAP {SHA}) |
 | sha1passsalt | 110 |
-| sha1saltpass | 120 |
 | ssha | 111 (NSLDAPS SSHA-1) |
-| 130 | (hashcat compatible sha1 utf16le($pass).$salt) |
-| 140 | (hashcat compatible sha1 $salt.utf16le($pass)) |
-| 150 | (hashcat compatible HMAC-SHA1 key = $pass) |
-| 160 | (hashcat compatible HMAC-SHA1 key = $salt) |
-| 170 | (hashcat compatible sha1 utf16le($pass)) |
+| sha1saltpass | 120 |
+| sha1utf16passsalt | 130 |
+| sha1utf16saltpass | 140 |
+| hmacsha1pass | 150 |
+| hmacsha1salt | 160 |
+| sha1utf16le | 170 |
+| sha1sha1 | 4500 |
+| 4700 | (sha1(md5($pass))) |
+| 18500 | (sha1(md5(md5($pass)))) |
+| 18501 | (sha1(md5(sha1($pass)))) |
 | | |
 | **`SHA2`** | |
 | sha224 | 1300 |
 | sha224passsalt | 1310 |
 | sha224saltpass | 1320 |
-| 34400 | (hashcat compatible sha224(sha224($pass))) |
-| 34500 | (hashcat compatible sha224(sha1($pass))) |
+| 34400 | (sha224(sha224($pass))) |
+| 34500 | (sha224(sha1($pass))) |
 | sha256 | 1400 |
 | sha256passsalt | 1410 |
-| sha256saltpass | 1420 |
-| 20800 | (hashcat compatible sha256(md5($pass))) |
-| 35900 | (sha256(sha1($pass))) |
 | ssha256 | 1411 (LDAP {SSHA256}) |
-| 1430 | (hashcat compatible sha256 utf16le($pass).$salt) |
-| 1440 | (hashcat compatible sha256 $salt.utf16le($pass)) |
-| 1450 | (hashcat compatible HMAC-SHA256 key = $pass) |
-| 1460 | (hashcat compatible HMAC-SHA256 key = $salt) |
-| 1470 | (hashcat compatible sha256 utf16le($pass)) |
+| sha256saltpass | 1420 |
+| sha256utf16passsalt | 1430 |
+| sha256utf16saltpass | 1440 |
+| hmacsha256pass | 1450 |
+| hmacsha256salt | 1460 |
+| sha256utf16le | 1470 |
+| 20800 | (sha256(md5($pass))) |
+| 35900 | (sha256(sha1($pass))) |
 | sha384 | 10800 |
 | sha384passsalt | 10810 |
 | sha384saltpass | 10820 |
-| 10830 | (hashcat compatible sha384 utf16le($pass).$salt) |
-| 10840 | (hashcat compatible sha384 $salt.utf16le($pass)) |
-| 10870 | (hashcat compatible sha384 utf16le($pass)) |
+| sha384utf16passsalt | 10830 |
+| sha384utf16saltpass | 10840 |
+| sha384utf16le | 10870 |
 | sha512 | 1700 |
 | sha512passsalt | 1710 |
-| sha512saltpass | 1720 |
 | ssha512 | 1711 (LDAP {SSHA512}) |
-| 1730 | (hashcat compatible sha512 utf16le($pass).$salt) |
-| 1740 | (hashcat compatible sha512 $salt.utf16le($pass)) |
-| 1750 | (hashcat compatible HMAC-SHA512 key = $pass) |
-| 1760 | (hashcat compatible HMAC-SHA512 key = $salt) |
-| 1770 | (hashcat compatible sha512 utf16le($pass)) |
-| sha512-224 | |
-| sha512-256 | |
+| sha512saltpass | 1720 |
+| sha512utf16passsalt | 1730 |
+| sha512utf16saltpass | 1740 |
+| hmacsha512pass | 1750 |
+| hmacsha512salt | 1760 |
+| sha512utf16le | 1770 |
+| sha512224 | |
+| sha512256 | |
 | | |
 | **`SHA3`** | |
-| sha3-224 | 17300 |
-| sha3-256 | 17400 |
-| sha3-384 | 17500 |
-| sha3-512 | 17600 |
+| sha3224 | 17300 |
+| sha3256 | 17400 |
+| sha3384 | 17500 |
+| sha3512 | 17600 |
 | | |
 | **`Keccak`** | |
-| keccak-224 | 17700 |
-| keccak-256 | 17800 |
-| keccak-384 | 17900 |
-| keccak-512 | 18000 |
+| keccak224 | 17700 |
+| keccak256 | 17800 |
+| keccak384 | 17900 |
+| keccak512 | 18000 |
 | | |
 | **`BLAKE2`** | |
-| blake2s-256 | |
-| 31000 | (hashcat compatible BLAKE2s-256) |
-| 33300 | (hashcat compatible HMAC-BLAKE2s key = $pass) |
-| blake2b-256 | |
-| 34800 | (hashcat compatible BLAKE2b-256) |
-| blake2b-384 | |
-| blake2b-512 | |
-| 600 | (hashcat compatible BLAKE2b-512) |
-| 610 | (hashcat compatible BLAKE2b-512 pass.salt) |
-| 620 | (hashcat compatible BLAKE2b-512 salt.pass) |
-| 34810 | (hashcat compatible BLAKE2b-256 pass.salt) |
-| 34820 | (hashcat compatible BLAKE2b-256 salt.pass) |
+| blake2s256 | |
+| 31000 | (BLAKE2s-256 $BLAKE2$ format) |
+| hmacblake2spass | 33300 |
+| blake2b256 | |
+| 34800 | (BLAKE2b-256 $BLAKE2$ format) |
+| blake2b256passsalt | 34810 |
+| blake2b256saltpass | 34820 |
+| blake2b384 | |
+| blake2b512 | |
+| 600 | (BLAKE2b-512 $BLAKE2$ format) |
+| blake2b512passsalt | 610 |
+| blake2b512saltpass | 620 |
 | | |
 | **`Other Hashes`** | |
 | ntlm | 1000 (Windows NT) |
 | mysql4/mysql5 | 300 |
-| ripemd-160 | 6000 |
-| 6050 | (hashcat compatible HMAC-RIPEMD160 key = $pass) |
-| 6060 | (hashcat compatible HMAC-RIPEMD160 key = $salt) |
+| ripemd160 | 6000 |
+| hmacripemd160pass | 6050 |
+| hmacripemd160salt | 6060 |
 | | |
 | **`Streebog / GOST R 34.11-2012`** | |
-| streebog-256 | 11700 |
-| 11750 | (HMAC-Streebog-256 key = $pass) |
-| 11760 | (HMAC-Streebog-256 key = $salt) |
-| streebog-512 | 11800 |
-| 11850 | (HMAC-Streebog-512 key = $pass) |
-| 11860 | (HMAC-Streebog-512 key = $salt) |
+| streebog256 | 11700 |
+| hmacstreebog256pass | 11750 |
+| hmacstreebog256salt | 11760 |
+| streebog512 | 11800 |
+| hmacstreebog512pass | 11850 |
+| hmacstreebog512salt | 11860 |
 | | |
 | **`Crypt / KDF`** | |
 | argon2id | 34000 |
@@ -205,32 +202,31 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 | bcryptsha1 | 25800 |
 | bcryptsha512 | 28400 |
 | bcryptsha256 | 30600 |
-| wpbcrypt | 35500 (`WordPress bcrypt-HMAC-SHA384`) |
-| md5crypt | 500 (`Linux shadow $1$`) |
-| sha1crypt | 15100 (`NetBSD/Juniper SHA1 crypt`) |
-| sha256crypt | 7400 (`Linux shadow $5$`) |
-| sha512crypt | 1800 (`Linux shadow $6$`) |
-| sm3crypt | 35100 (`Unix $sm3$`) |
-| cmiyc | (`KoreLogic CMIYC 2026 contest algo`) |
-| phpass | 400 (`PHP/WordPress $P$/phpBB3 $H$`) |
-| gost-yescrypt | (`Linux shadow $gy$`) |
-| yescrypt | (`Linux shadow $y$`) |
+| wpbcrypt | 35500 (WordPress bcrypt-HMAC-SHA384) |
+| md5crypt | 500 (Linux shadow $1$) |
+| sha1crypt | 15100 (NetBSD/Juniper SHA1 crypt) |
+| sha256crypt | 7400 (Linux shadow $5$) |
+| sha512crypt | 1800 (Linux shadow $6$) |
+| sm3crypt | 35100 (Unix $sm3$) |
+| phpass/phpbb3 | 400 ($P$ / $H$) |
 | scrypt | 8900 |
-| 10900 | (hashcat compatible PBKDF2-HMAC-SHA256) |
-| 11900 | (hashcat compatible PBKDF2-HMAC-MD5) |
-| 12000 | (hashcat compatible PBKDF2-HMAC-SHA1) |
-| 12100 | (hashcat compatible PBKDF2-HMAC-SHA512) |
+| pbkdf2sha256 | 10900 |
+| pbkdf2md5 | 11900 |
+| pbkdf2sha1 | 12000 |
+| pbkdf2sha512 | 12100 |
+| yescrypt | (Linux shadow $y$) |
+| gostyescrypt | (Linux shadow $gy$) |
+| cmiyc | (KoreLogic CMIYC 2026 contest algorithm) |
 
 ### Benchmarks:
 - https://github.com/cyclone-github/hashgen-testing/tree/main/benchmarks
-- In addition to hashgen (go), I have also written hashgen in python, php, C, and Rust, although Rust and C need a lot of work to unlock their full performance potential. If you speak C or Rust, I'd be curious to see how fast you can push hashgen!
+- In addition to hashgen (Go), I have also written hashgen in Python, PHP, C, and Rust, although Rust and C need a lot of work to unlock their full performance potential. If you speak C or Rust, I'd be curious to see how fast you can push hashgen!
   - https://github.com/cyclone-github/hashgen-testing
 
 ### Compile from source:
 - This assumes you have Go and Git installed
   - `git clone https://github.com/cyclone-github/hashgen.git`  # clone repo
   - `cd hashgen`                                               # enter project directory
-  - `go mod init hashgen`                                      # initialize Go module (skips if go.mod exists)
   - `go mod tidy`                                              # download dependencies
   - `go build -ldflags="-s -w" .`                              # compile binary in current directory
   - `go install -ldflags="-s -w" .`                            # compile binary and install to $GOPATH
@@ -239,7 +235,7 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 
 ### Changelog:
 - https://github.com/cyclone-github/hashgen/blob/main/CHANGELOG.md
- 
+
 ### Mentions:
 - Go Package Documentation: https://pkg.go.dev/github.com/cyclone-github/hashgen
 - hashcat wiki: https://hashcat.net/wiki/
@@ -253,8 +249,8 @@ To use hashgen, type your mode, wordlist input & hash output files with a simple
 - Uploading your compiled hashgen binaries to https://virustotal.com and leaving an upvote or a comment would be helpful.
 
 ### Thoughts:
-- Why write hashgen? hashgen is nothing new (to me) as this project started several years ago while needing a way to quickly convert wordlists to md5 or sha1 on linux terminal. Several versions of hashgen have been written over the years in several languages: python, php, Go, C and Rust. While the actively maintained version is hashgen (go), which offers enhanced features and superior performance, the "hashgen-testing" repository linked below contains testing versions of hashgen in different programming languages:
+- Why write hashgen? hashgen is nothing new (to me) as this project started several years ago while needing a way to quickly convert wordlists to md5 or sha1 on a Linux terminal. Several versions of hashgen have been written over the years in several languages: Python, PHP, Go, C and Rust. While the actively maintained version is hashgen (Go), which offers enhanced features and superior performance, the "hashgen-testing" repository linked below contains testing versions of hashgen in different programming languages:
   - https://github.com/cyclone-github/hashgen-testing
 - Why write hashgen in Go instead of xyz language? I did this to push my Go coding skills while also seeing how fast I could push Go. During early testing, I was not expecting hashgen to be all that fast, but I have been pleasantly surprised!
-- When I realized hashgen (go) was competitively fast compared to other publicly available hash generators, I decided to publish hashgen's code and binaries for others to use. I've really enjoyed this project and I hope you find it useful.
+- When I realized hashgen (Go) was competitively fast compared to other publicly available hash generators, I decided to publish hashgen's code and binaries for others to use. I've really enjoyed this project and I hope you find it useful.
 - If you found hashgen to be helpful, please consider giving this repository a star!

--- a/hashgen.go
+++ b/hashgen.go
@@ -46,7 +46,7 @@ import (
 )
 
 /*
-hashgen is a CLI hash generator which can be cross compiled for Linux, Raspberry Pi, Windows & Mac
+hashgen is a CLI hash generator which can be cross-compiled for Linux, Raspberry Pi, Windows & Mac
 https://github.com/cyclone-github/hashgen
 written by cyclone
 
@@ -64,7 +64,7 @@ v1.3.0; 2026-04-11
 	added HMAC modes: -m 50, 60, 150, 160, 1450, 1460, 1750, 1760, 6050, 6060
 	added UTF-16LE modes: -m 30, 40, 70, 130, 140, 170, 1430, 1440, 1470, 1730, 1740, 1770
 	optimized salt RNG for fewer syscalls on salted hash modes
-	added sanity check on invalid -m nth before opening stdin/wordlist
+	added sanity check on invalid -m mode before opening stdin/wordlist
 	compiled with Go v1.26.2
 v1.3.1; 2026-04-13
 	add modes: MD6-128, MD6-224, MD6-256, MD6-384, MD6-512
@@ -73,7 +73,7 @@ v1.3.2; 2026-08-18
 	add mode: SSHA -m 111
 	add mode: sha1crypt -m 15100
 	add mode: sm3crypt -m 35100
-	add mode: cmiyc (KoreLogic CMIYC 2026 contest algo)
+	add mode: cmiyc (KoreLogic CMIYC 2026 contest algorithm)
 	add modes: Streebog/GOST 2012 -m 11700, 11750, 11760, 11800, 11850, 11860
 	add modes: SHA-384 UTF-16LE -m 10830, 10840, 10870
 	add modes: LDAP SHA/SSHA -m 101, 1411, 1711
@@ -99,139 +99,150 @@ func helpFunc() {
 		"\nIf -w is not specified, defaults to stdin\n" +
 		"If -o is not specified, defaults to stdout\n" +
 		"If -t is not specified, defaults to max available CPU threads\n" +
-		"\nModes:\t\tHashcat Mode (notes):\n" +
-		"argon2id\t34000\n" +
+		"\nModes:\t\t\tHashcat Mode (notes):\n" +
+		"plaintext/dehex		99999 (decode $HEX[])\n" +
+		"hex			(encode to $HEX[])\n" +
 		"base32decode\n" +
 		"base32encode\n" +
 		"base58decode\n" +
 		"base58encode\n" +
 		"base64decode\n" +
 		"base64encode\n" +
-		"bcrypt\t\t3200\n" +
-		"bcryptmd5\t25600\n" +
-		"bcryptsha1\t25800\n" +
-		"bcryptsha512\t28400\n" +
-		"bcryptsha256\t30600\n" +
-		"wpbcrypt\t35500 (WordPress bcrypt-HMAC-SHA384)\n" +
-		"blake2s-256\n" +
-		"31000\t\t(hashcat compatible BLAKE2s-256)\n" +
-		"33300\t\t(hashcat compatible HMAC-BLAKE2s key = $pass)\n" +
-		"blake2b-256\n" +
-		"34800\t\t(hashcat compatible BLAKE2b-256)\n" +
-		"blake2b-384\n" +
-		"blake2b-512\n" +
-		"600\t\t(hashcat compatible BLAKE2b-512)\n" +
-		"610\t\t(hashcat compatible BLAKE2b-512 pass.salt)\n" +
-		"620\t\t(hashcat compatible BLAKE2b-512 salt.pass)\n" +
-		"34810\t\t(hashcat compatible BLAKE2b-256 pass.salt)\n" +
-		"34820\t\t(hashcat compatible BLAKE2b-256 salt.pass)\n" +
+		"morsecode		(ITU-R M.1677-1)\n" +
+		"morsedecode		(ITU-R M.1677-1)\n" +
+		"\n" +
 		"crc32\n" +
-		"11500\t\t(hashcat compatible CRC32)\n" +
+		"11500			(CRC32 Hashcat format)\n" +
 		"crc64\n" +
-		"hex\t\t(encode to $HEX[])\n" +
-		"dehex/plaintext\t99999 (decode $HEX[])\n" +
-		"md4\t\t900\n" +
-		"md5\t\t0\n" +
-		"halfmd5\t\t5100\n" +
-		"md5passsalt\t10\n" +
-		"md5saltpass\t20\n" +
-		"30\t\t(hashcat compatible md5 utf16le($pass).$salt)\n" +
-		"40\t\t(hashcat compatible md5 $salt.utf16le($pass))\n" +
-		"70\t\t(hashcat compatible md5 utf16le($pass))\n" +
-		"md5md5\t\t2600\n" +
-		"3500\t\t(hashcat compatible md5(md5(md5($pass))))\n" +
-		"4300\t\t(hashcat compatible md5(strtoupper(md5($pass))))\n" +
-		"4400\t\t(hashcat compatible md5(sha1($pass)))\n" +
-		"32800\t\t(hashcat compatible md5(sha1(md5($pass))))\n" +
-		"md5crypt\t500 (Linux shadow $1$)\n" +
-		"md6-128\n" +
-		"md6-224\n" +
-		"md6-256\t\t34600\n" +
-		"md6-384\n" +
-		"md6-512\n" +
-		"mysql4/mysql5\t300\n" +
-		"morsecode\t(ITU-R M.1677-1)\n" +
-		"morsedecode\t(ITU-R M.1677-1)\n" +
-		"ntlm\t\t1000 (Windows NT)\n" +
-		"phpass\t\t400\n" +
-		"ripemd-160\t6000\n" +
-		"sha1\t\t100\n" +
-		"ldap-sha\t101 (Netscape LDAP {SHA})\n" +
-		"sha1sha1\t4500\n" +
-		"4700\t\t(hashcat compatible sha1(md5($pass)))\n" +
-		"18500\t\t(hashcat compatible sha1(md5(md5($pass))))\n" +
-		"18501\t\t(sha1(md5(sha1($pass))))\n" +
-		"sha1passsalt\t110\n" +
-		"sha1saltpass\t120\n" +
-		"sha1crypt\t15100 (NetBSD/Juniper SHA1 crypt)\n" +
-		"ssha\t\t111 (NSLDAPS SSHA-1)\n" +
-		"130\t\t(hashcat compatible sha1 utf16le($pass).$salt)\n" +
-		"140\t\t(hashcat compatible sha1 $salt.utf16le($pass))\n" +
-		"170\t\t(hashcat compatible sha1 utf16le($pass))\n" +
-		"sha224\t\t1300\n" +
-		"sha224passsalt\t1310\n" +
-		"sha224saltpass\t1320\n" +
-		"34400\t\t(hashcat compatible sha224(sha224($pass)))\n" +
-		"34500\t\t(hashcat compatible sha224(sha1($pass)))\n" +
-		"sha256\t\t1400\n" +
-		"sha256passsalt\t1410\n" +
-		"sha256saltpass\t1420\n" +
-		"20800\t\t(hashcat compatible sha256(md5($pass)))\n" +
-		"35900\t\t(sha256(sha1($pass)))\n" +
-		"ssha256\t\t1411 (LDAP {SSHA256})\n" +
-		"1430\t\t(hashcat compatible sha256 utf16le($pass).$salt)\n" +
-		"1440\t\t(hashcat compatible sha256 $salt.utf16le($pass))\n" +
-		"1470\t\t(hashcat compatible sha256 utf16le($pass))\n" +
-		"sha256crypt\t7400 (Linux shadow $5$)\n" +
-		"sha384\t\t10800\n" +
-		"sha384passsalt\t10810\n" +
-		"sha384saltpass\t10820\n" +
-		"10830\t\t(hashcat compatible sha384 utf16le($pass).$salt)\n" +
-		"10840\t\t(hashcat compatible sha384 $salt.utf16le($pass))\n" +
-		"10870\t\t(hashcat compatible sha384 utf16le($pass))\n" +
-		"sha512\t\t1700\n" +
-		"sha512passsalt\t1710\n" +
-		"sha512saltpass\t1720\n" +
-		"ssha512\t\t1711 (LDAP {SSHA512})\n" +
-		"1730\t\t(hashcat compatible sha512 utf16le($pass).$salt)\n" +
-		"1740\t\t(hashcat compatible sha512 $salt.utf16le($pass))\n" +
-		"1770\t\t(hashcat compatible sha512 utf16le($pass))\n" +
-		"sha512crypt\t1800 (Linux shadow $6$)\n" +
-		"sm3crypt\t35100 (Unix $sm3$)\n" +
-		"cmiyc\t\t(KoreLogic CMIYC 2026 contest algo)\n" +
-		"50\t\t(hashcat compatible HMAC-MD5 key = $pass)\n" +
-		"60\t\t(hashcat compatible HMAC-MD5 key = $salt)\n" +
-		"150\t\t(hashcat compatible HMAC-SHA1 key = $pass)\n" +
-		"160\t\t(hashcat compatible HMAC-SHA1 key = $salt)\n" +
-		"1450\t\t(hashcat compatible HMAC-SHA256 key = $pass)\n" +
-		"1460\t\t(hashcat compatible HMAC-SHA256 key = $salt)\n" +
-		"1750\t\t(hashcat compatible HMAC-SHA512 key = $pass)\n" +
-		"1760\t\t(hashcat compatible HMAC-SHA512 key = $salt)\n" +
-		"6050\t\t(hashcat compatible HMAC-RIPEMD160 key = $pass)\n" +
-		"6060\t\t(hashcat compatible HMAC-RIPEMD160 key = $salt)\n" +
-		"streebog-256\t11700\n" +
-		"11750\t\t(hashcat compatible HMAC-Streebog-256 key = $pass)\n" +
-		"11760\t\t(hashcat compatible HMAC-Streebog-256 key = $salt)\n" +
-		"streebog-512\t11800\n" +
-		"11850\t\t(hashcat compatible HMAC-Streebog-512 key = $pass)\n" +
-		"11860\t\t(hashcat compatible HMAC-Streebog-512 key = $salt)\n" +
-		"10900\t\t(hashcat compatible PBKDF2-HMAC-SHA256)\n" +
-		"11900\t\t(hashcat compatible PBKDF2-HMAC-MD5)\n" +
-		"12000\t\t(hashcat compatible PBKDF2-HMAC-SHA1)\n" +
-		"12100\t\t(hashcat compatible PBKDF2-HMAC-SHA512)\n" +
-		"sha512-224\n" +
-		"sha512-256\n" +
-		"sha3-224\t17300\n" +
-		"sha3-256\t17400\n" +
-		"sha3-384\t17500\n" +
-		"sha3-512\t17600\n" +
-		"keccak-224\t17700\n" +
-		"keccak-256\t17800\n" +
-		"keccak-384\t17900\n" +
-		"keccak-512\t18000\n" +
-		"scrypt\t\t8900\n" +
-		"gost-yescrypt\t(Linux shadow $gy$)\n" +
-		"yescrypt\t(Linux shadow $y$)\n"
+		"\n" +
+		"md4			900\n" +
+		"md5			0\n" +
+		"halfmd5			5100\n" +
+		"md5passsalt		10\n" +
+		"md5saltpass		20\n" +
+		"md5utf16passsalt	30\n" +
+		"md5utf16saltpass	40\n" +
+		"hmacmd5pass		50\n" +
+		"hmacmd5salt		60\n" +
+		"md5utf16le		70\n" +
+		"md5md5			2600\n" +
+		"3500			(md5(md5(md5($pass))))\n" +
+		"4300			(md5(strtoupper(md5($pass))))\n" +
+		"4400			(md5(sha1($pass)))\n" +
+		"32800			(md5(sha1(md5($pass))))\n" +
+		"\n" +
+		"md6128\n" +
+		"md6224\n" +
+		"md6256			34600\n" +
+		"md6384\n" +
+		"md6512\n" +
+		"\n" +
+		"sha1			100\n" +
+		"ldapsha			101 (Netscape LDAP {SHA})\n" +
+		"sha1passsalt		110\n" +
+		"ssha			111 (NSLDAPS SSHA-1)\n" +
+		"sha1saltpass		120\n" +
+		"sha1utf16passsalt	130\n" +
+		"sha1utf16saltpass	140\n" +
+		"hmacsha1pass		150\n" +
+		"hmacsha1salt		160\n" +
+		"sha1utf16le		170\n" +
+		"sha1sha1		4500\n" +
+		"4700			(sha1(md5($pass)))\n" +
+		"18500			(sha1(md5(md5($pass))))\n" +
+		"18501			(sha1(md5(sha1($pass))))\n" +
+		"\n" +
+		"sha224			1300\n" +
+		"sha224passsalt		1310\n" +
+		"sha224saltpass		1320\n" +
+		"34400			(sha224(sha224($pass)))\n" +
+		"34500			(sha224(sha1($pass)))\n" +
+		"sha256			1400\n" +
+		"sha256passsalt		1410\n" +
+		"ssha256			1411 (LDAP {SSHA256})\n" +
+		"sha256saltpass		1420\n" +
+		"sha256utf16passsalt	1430\n" +
+		"sha256utf16saltpass	1440\n" +
+		"hmacsha256pass		1450\n" +
+		"hmacsha256salt		1460\n" +
+		"sha256utf16le		1470\n" +
+		"20800			(sha256(md5($pass)))\n" +
+		"35900			(sha256(sha1($pass)))\n" +
+		"sha384			10800\n" +
+		"sha384passsalt		10810\n" +
+		"sha384saltpass		10820\n" +
+		"sha384utf16passsalt	10830\n" +
+		"sha384utf16saltpass	10840\n" +
+		"sha384utf16le		10870\n" +
+		"sha512			1700\n" +
+		"sha512passsalt		1710\n" +
+		"ssha512			1711 (LDAP {SSHA512})\n" +
+		"sha512saltpass		1720\n" +
+		"sha512utf16passsalt	1730\n" +
+		"sha512utf16saltpass	1740\n" +
+		"hmacsha512pass		1750\n" +
+		"hmacsha512salt		1760\n" +
+		"sha512utf16le		1770\n" +
+		"sha512224\n" +
+		"sha512256\n" +
+		"\n" +
+		"sha3224			17300\n" +
+		"sha3256			17400\n" +
+		"sha3384			17500\n" +
+		"sha3512			17600\n" +
+		"\n" +
+		"keccak224		17700\n" +
+		"keccak256		17800\n" +
+		"keccak384		17900\n" +
+		"keccak512		18000\n" +
+		"\n" +
+		"blake2s256\n" +
+		"31000			(BLAKE2s-256 $BLAKE2$ format)\n" +
+		"hmacblake2spass		33300\n" +
+		"blake2b256\n" +
+		"34800			(BLAKE2b-256 $BLAKE2$ format)\n" +
+		"blake2b256passsalt	34810\n" +
+		"blake2b256saltpass	34820\n" +
+		"blake2b384\n" +
+		"blake2b512\n" +
+		"600			(BLAKE2b-512 $BLAKE2$ format)\n" +
+		"blake2b512passsalt	610\n" +
+		"blake2b512saltpass	620\n" +
+		"\n" +
+		"ntlm			1000 (Windows NT)\n" +
+		"mysql4/mysql5		300\n" +
+		"ripemd160		6000\n" +
+		"hmacripemd160pass	6050\n" +
+		"hmacripemd160salt	6060\n" +
+		"\n" +
+		"streebog256		11700\n" +
+		"hmacstreebog256pass	11750\n" +
+		"hmacstreebog256salt	11760\n" +
+		"streebog512		11800\n" +
+		"hmacstreebog512pass	11850\n" +
+		"hmacstreebog512salt	11860\n" +
+		"\n" +
+		"argon2id		34000\n" +
+		"bcrypt			3200\n" +
+		"bcryptmd5		25600\n" +
+		"bcryptsha1		25800\n" +
+		"bcryptsha512		28400\n" +
+		"bcryptsha256		30600\n" +
+		"wpbcrypt		35500 (WordPress bcrypt-HMAC-SHA384)\n" +
+		"md5crypt		500 (Linux shadow $1$)\n" +
+		"sha1crypt		15100 (NetBSD/Juniper SHA1 crypt)\n" +
+		"sha256crypt		7400 (Linux shadow $5$)\n" +
+		"sha512crypt		1800 (Linux shadow $6$)\n" +
+		"sm3crypt		35100 (Unix $sm3$)\n" +
+		"phpass/phpbb3		400 ($P$ / $H$)\n" +
+		"scrypt			8900\n" +
+		"pbkdf2sha256		10900\n" +
+		"pbkdf2md5		11900\n" +
+		"pbkdf2sha1		12000\n" +
+		"pbkdf2sha512		12100\n" +
+		"yescrypt		(Linux shadow $y$)\n" +
+		"gostyescrypt		(Linux shadow $gy$)\n" +
+		"cmiyc			(KoreLogic CMIYC 2026 contest algorithm)"
 	fmt.Fprintln(os.Stderr, str)
 	os.Exit(0)
 }
@@ -248,7 +259,7 @@ var modeProbe bool
 
 func isPBKDF2Mode(m string) bool {
 	switch m {
-	case "10900", "pbkdf2-sha256", "11900", "pbkdf2-md5", "12000", "pbkdf2-sha1", "12100", "pbkdf2-sha512":
+	case "10900", "pbkdf2sha256", "pbkdf2-sha256", "11900", "pbkdf2md5", "pbkdf2-md5", "12000", "pbkdf2sha1", "pbkdf2-sha1", "12100", "pbkdf2sha512", "pbkdf2-sha512":
 		return true
 	default:
 		return false
@@ -364,7 +375,7 @@ func sha512HexBytes(data []byte) [128]byte {
 
 // LDAP SHA/SSHA family -m 101 / 111 / 1411 / 1711
 func ldapSHA(password []byte, mode string, saltRaw []byte) string {
-	if mode == "101" || mode == "ldap-sha" {
+	if mode == "101" || mode == "ldapsha" || mode == "ldap-sha" {
 		digest := sha1.Sum(password)
 		return "{SHA}" + base64.StdEncoding.EncodeToString(digest[:])
 	}
@@ -687,7 +698,7 @@ func phpassMD5(password []byte, mode string, countLog2 int, saltRaw []byte) stri
 	if countLog2 <= 0 {
 		countLog2 = 11
 	}
-	if saltRaw == nil || len(saltRaw) < 6 {
+	if len(saltRaw) < 6 {
 		saltRaw = make([]byte, 6)
 		if !readRand(saltRaw) {
 			return ""
@@ -748,7 +759,7 @@ func phpassMD5(password []byte, mode string, countLog2 int, saltRaw []byte) stri
 	return string(out)
 }
 
-// md5crypt - linux shadow "$1$<salt>$<hash>"
+// md5crypt - Linux shadow "$1$<salt>$<hash>"
 func md5crypt(password []byte) string {
 	const magic = "$1$"
 	salt := make([]byte, 8)
@@ -862,7 +873,7 @@ func md5crypt(password []byte) string {
 	return string(out)
 }
 
-// sha256crypt - linux shadow $5$[rounds=R$]<salt>$<hash>
+// sha256crypt - Linux shadow $5$[rounds=R$]<salt>$<hash>
 func sha256crypt(password []byte) string {
 	const magic = "$5$"
 	rounds := 5000
@@ -978,7 +989,7 @@ func sha256crypt(password []byte) string {
 	return string(out)
 }
 
-// sha512crypt - linux shadow ($6$)
+// sha512crypt - Linux shadow ($6$)
 func sha512crypt(password []byte) string {
 	const magic = "$6$"
 	const rounds = 5000
@@ -1295,7 +1306,7 @@ const (
 
 var cmiycMemPool = sync.Pool{New: func() any { return make([]byte, cmiycMemSize) }}
 
-// cmiyc 2026 contest algo - memory-hard SHA-512 KDF
+// cmiyc 2026 contest algorithm - memory-hard SHA-512 KDF
 func cmiyc(password []byte, saltRaw []byte) string {
 	var salt [16]byte
 	if len(saltRaw) >= len(salt) {
@@ -1411,9 +1422,9 @@ func wpbcrypt(password []byte, cost int) string {
 	return wpPrefix + s[1:]
 }
 
-// yescrypt, using debian/libxcrypt defaults
+// yescrypt, using Debian/libxcrypt defaults
 func yescryptHash(pass []byte) string {
-	// debian/libxcrypt defaults: N=4096, r=32, p=1, keyLen=32, 128-bit salt
+	// Debian/libxcrypt defaults: N=4096, r=32, p=1, keyLen=32, 128-bit salt
 	const N = 4096
 	const r = 32
 	const p = 1
@@ -1467,7 +1478,7 @@ func yescryptHash(pass []byte) string {
 	return "$y$" + string(params) + "$" + encode64(salt) + "$" + encode64(key)
 }
 
-// gost-yescrypt, using debian/libxcrypt defaults
+// gost-yescrypt, using Debian/libxcrypt defaults
 func gostYescryptHash(pass []byte) string {
 	const N = 4096
 	const r = 32
@@ -1535,16 +1546,16 @@ func isBcryptMode(mode string) bool {
 	}
 }
 
-// supported hash algos / modes
+// supported hash algorithms / modes
 func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 	if modeProbe {
 		if isBcryptMode(hashFunc) {
 			return "", true
 		}
 		switch hashFunc {
-		case "argon2id", "34000", "yescrypt", "gost-yescrypt",
+		case "argon2id", "34000", "yescrypt", "gostyescrypt", "gost-yescrypt",
 			"8900", "scrypt",
-			"10900", "pbkdf2-sha256", "11900", "pbkdf2-md5", "12000", "pbkdf2-sha1", "12100", "pbkdf2-sha512",
+			"10900", "pbkdf2sha256", "pbkdf2-sha256", "11900", "pbkdf2md5", "pbkdf2-md5", "12000", "pbkdf2sha1", "pbkdf2-sha1", "12100", "pbkdf2sha512", "pbkdf2-sha512",
 			"md5crypt", "500", "sha1crypt", "15100", "sha256crypt", "7400", "sha512crypt", "1800", "sm3crypt", "35100", "cmiyc",
 			"phpass", "phpbb3", "400":
 			return "", true
@@ -1794,7 +1805,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return hex.EncodeToString(h[:]), true
 
 	// LDAP SHA/SSHA -m 101 / 111 / 1411 / 1711
-	case "ldap-sha", "101", "ssha", "111", "ssha256", "1411", "ssha512", "1711":
+	case "ldapsha", "ldap-sha", "101", "ssha", "111", "ssha256", "1411", "ssha512", "1711":
 		return ldapSHA(data, hashFunc, nil), true
 
 	// -m 110 sha1(pass.salt), -m 120 sha1(salt.pass)
@@ -2174,14 +2185,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 
 	// HMAC (hashcat: hex_digest : salt)
 
-	case "50", "hmac-md5-pass", "60", "hmac-md5-salt":
+	case "50", "hmacmd5pass", "hmac-md5-pass", "60", "hmacmd5salt", "hmac-md5-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "50" || hashFunc == "hmac-md5-pass" {
+		if hashFunc == "50" || hashFunc == "hmacmd5pass" || hashFunc == "hmac-md5-pass" {
 			h := hmac.New(md5.New, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2192,14 +2203,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		}
 		return hexMACLineDigest(m, salt), true
 
-	case "150", "hmac-sha1-pass", "160", "hmac-sha1-salt":
+	case "150", "hmacsha1pass", "hmac-sha1-pass", "160", "hmacsha1salt", "hmac-sha1-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "150" || hashFunc == "hmac-sha1-pass" {
+		if hashFunc == "150" || hashFunc == "hmacsha1pass" || hashFunc == "hmac-sha1-pass" {
 			h := hmac.New(sha1.New, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2210,14 +2221,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		}
 		return hexMACLineDigest(m, salt), true
 
-	case "1450", "hmac-sha256-pass", "1460", "hmac-sha256-salt":
+	case "1450", "hmacsha256pass", "hmac-sha256-pass", "1460", "hmacsha256salt", "hmac-sha256-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "1450" || hashFunc == "hmac-sha256-pass" {
+		if hashFunc == "1450" || hashFunc == "hmacsha256pass" || hashFunc == "hmac-sha256-pass" {
 			h := hmac.New(sha256.New, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2228,14 +2239,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		}
 		return hexMACLineDigest(m, salt), true
 
-	case "1750", "hmac-sha512-pass", "1760", "hmac-sha512-salt":
+	case "1750", "hmacsha512pass", "hmac-sha512-pass", "1760", "hmacsha512salt", "hmac-sha512-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "1750" || hashFunc == "hmac-sha512-pass" {
+		if hashFunc == "1750" || hashFunc == "hmacsha512pass" || hashFunc == "hmac-sha512-pass" {
 			h := hmac.New(sha512.New, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2246,14 +2257,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		}
 		return hexMACLineDigest(m, salt), true
 
-	case "6050", "hmac-ripemd160-pass", "6060", "hmac-ripemd160-salt":
+	case "6050", "hmacripemd160pass", "hmac-ripemd160-pass", "6060", "hmacripemd160salt", "hmac-ripemd160-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "6050" || hashFunc == "hmac-ripemd160-pass" {
+		if hashFunc == "6050" || hashFunc == "hmacripemd160pass" || hashFunc == "hmac-ripemd160-pass" {
 			h := hmac.New(ripemd160.New, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2264,14 +2275,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		}
 		return hexMACLineDigest(m, salt), true
 
-	case "11750", "hmac-streebog256-pass", "11760", "hmac-streebog256-salt":
+	case "11750", "hmacstreebog256pass", "hmac-streebog256-pass", "11760", "hmacstreebog256salt", "hmac-streebog256-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "11750" || hashFunc == "hmac-streebog256-pass" {
+		if hashFunc == "11750" || hashFunc == "hmacstreebog256pass" || hashFunc == "hmac-streebog256-pass" {
 			h := hmac.New(streebog.New256, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2283,14 +2294,14 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		reverseBytes(m)
 		return hexMACLineDigest(m, salt), true
 
-	case "11850", "hmac-streebog512-pass", "11860", "hmac-streebog512-salt":
+	case "11850", "hmacstreebog512pass", "hmac-streebog512-pass", "11860", "hmacstreebog512salt", "hmac-streebog512-salt":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
 		}
 		salt := saltBuf[:]
 		var m []byte
-		if hashFunc == "11850" || hashFunc == "hmac-streebog512-pass" {
+		if hashFunc == "11850" || hashFunc == "hmacstreebog512pass" || hashFunc == "hmac-streebog512-pass" {
 			h := hmac.New(streebog.New512, data)
 			h.Write(salt)
 			m = h.Sum(nil)
@@ -2398,7 +2409,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return string(buf), true
 
 	// hashcat -m 33300 HMAC-BLAKE2s (key = $pass)
-	case "33300", "hmac-blake2s-pass":
+	case "33300", "hmacblake2spass", "hmac-blake2s-pass":
 		var saltBuf [16]byte
 		if !fillSaltHex8(saltBuf[:]) {
 			return "", true
@@ -2451,7 +2462,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 	// Crypt / KDF
 
 	// PBKDF2-HMAC-SHA256 -m 10900
-	case "10900", "pbkdf2-sha256":
+	case "10900", "pbkdf2sha256", "pbkdf2-sha256":
 		var salt [8]byte
 		if !readRand(salt[:]) {
 			return "", true
@@ -2460,7 +2471,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return fmt.Sprintf("sha256:%d:%s:%s", pbkdf2IterCount, base64.StdEncoding.EncodeToString(salt[:]), base64.StdEncoding.EncodeToString(dk)), true
 
 	// PBKDF2-HMAC-MD5 -m 11900
-	case "11900", "pbkdf2-md5":
+	case "11900", "pbkdf2md5", "pbkdf2-md5":
 		var salt [8]byte
 		if !readRand(salt[:]) {
 			return "", true
@@ -2469,7 +2480,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return fmt.Sprintf("md5:%d:%s:%s", pbkdf2IterCount, base64.StdEncoding.EncodeToString(salt[:]), base64.StdEncoding.EncodeToString(dk)), true
 
 	// PBKDF2-HMAC-SHA1 -m 12000
-	case "12000", "pbkdf2-sha1":
+	case "12000", "pbkdf2sha1", "pbkdf2-sha1":
 		var salt [8]byte
 		if !readRand(salt[:]) {
 			return "", true
@@ -2478,7 +2489,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return fmt.Sprintf("sha1:%d:%s:%s", pbkdf2IterCount, base64.StdEncoding.EncodeToString(salt[:]), base64.StdEncoding.EncodeToString(dk)), true
 
 	// PBKDF2-HMAC-SHA512 -m 12100
-	case "12100", "pbkdf2-sha512":
+	case "12100", "pbkdf2sha512", "pbkdf2-sha512":
 		var salt [8]byte
 		if !readRand(salt[:]) {
 			return "", true
@@ -2540,7 +2551,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		prehash := sha256HexBytes(data)
 		return bcryptHash(prehash[:], cost), true
 
-	// wordpress bcrypt -m 35500
+	// WordPress bcrypt -m 35500
 	case "wpbcrypt", "35500":
 		return wpbcrypt(data, cost), true
 
@@ -2577,7 +2588,7 @@ func hashBytesDispatch(hashFunc string, data []byte, cost int) (string, bool) {
 		return yescryptHash(data), true
 
 	// gost-yescrypt
-	case "gost-yescrypt":
+	case "gostyescrypt", "gost-yescrypt":
 		return gostYescryptHash(data), true
 
 	default:
@@ -2622,7 +2633,7 @@ func startProc(hashFunc string, inputFile string, outputPath string, hashPlainOu
 	//var readBufferSize = 1024 * 1024 // read buffer
 	var readBufferSize = numGoroutines + 16*32*1024 // variable read buffer
 
-	// lower read buffer for slow(ish) algos
+	// lower read buffer for slow(ish) algorithms
 	{
 		bufFixed := map[string]bool{
 			"phpass": true, "phpbb3": true, "400": true,
@@ -2631,10 +2642,10 @@ func startProc(hashFunc string, inputFile string, outputPath string, hashPlainOu
 			"sm3crypt": true, "35100": true,
 			"sha256crypt": true, "7400": true,
 			"sha512crypt": true, "1800": true,
-			"10900": true, "pbkdf2-sha256": true,
-			"11900": true, "pbkdf2-md5": true,
-			"12000": true, "pbkdf2-sha1": true,
-			"12100": true, "pbkdf2-sha512": true,
+			"10900": true, "pbkdf2sha256": true, "pbkdf2-sha256": true,
+			"11900": true, "pbkdf2md5": true, "pbkdf2-md5": true,
+			"12000": true, "pbkdf2sha1": true, "pbkdf2-sha1": true,
+			"12100": true, "pbkdf2sha512": true, "pbkdf2-sha512": true,
 		}
 		if bufFixed[hashFunc] {
 			readBufferSize = numGoroutines + 16*32
@@ -2650,7 +2661,7 @@ func startProc(hashFunc string, inputFile string, outputPath string, hashPlainOu
 	{
 		bufSlow := map[string]bool{
 			"argon2id": true, "34000": true,
-			"yescrypt": true, "gost-yescrypt": true,
+			"yescrypt": true, "gostyescrypt": true, "gost-yescrypt": true,
 			"cmiyc": true,
 			"8900":  true, "scrypt": true,
 		}
@@ -2874,9 +2885,9 @@ func main() {
 		helpFunc()
 	}
 
-	// run sanity checks on algo input (-m)
+	// run sanity checks on mode input (-m)
 	if *hashFunc == "" {
-		log.Fatalf("--> missing '-m algo' <--\n")
+		log.Fatalf("--> missing '-m mode' <--")
 	}
 	modeProbe = true
 	_, ok := hashBytesDispatch(*hashFunc, nil, *costFlag)


### PR DESCRIPTION
Clean up hashgen documentation and mode descriptions for better consistency in -help and README.

- Fix typos and formatting issues in `hashgen.go` and `README.md`
- Reorder modes by hash family and keep README/help ordering consistent
- Standardize canonical mode aliases and Hashcat mode formatting
- Remove redundant `hashcat compatible` wording where the numeric mode already makes that clear
- Support both dashed and non-dashed mode aliases
- Fix redundant `saltRaw == nil` check in `-m 400` phpass handling
- Remove duplicate/redundant newlines and other whitespace issues that can trigger CI warnings